### PR TITLE
config/update-base-info-version

### DIFF
--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -257,11 +257,11 @@
       "blockchain": "base",
       "chainId": 8453,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-03-04T08:46:07.865Z",
+      "timestamp": "2026-03-10T013:46:07.865Z",
       "version": {
         "major": 0,
         "minor": 1,
-        "patch": 6
+        "patch": 7
       }
     }
   ]


### PR DESCRIPTION
## Problem
Base mainnet version metadata in info.json was outdated.
## Solution
- Updated timestamp and patch version for Base mainnet in blockchains/info.json.
## Affected
- blockchains/info.json