### PR TITLE
config/base-bump-patch-version

### DIFF
--- a/blockchains/info.json
+++ b/blockchains/info.json
@@ -257,11 +257,11 @@
       "blockchain": "base",
       "chainId": 8453,
       "list": "assets.mainnet.json",
-      "timestamp": "2026-03-10T09:46:08.887Z",
+      "timestamp": "2026-03-11T09:46:08.887Z",
       "version": {
         "major": 0,
         "minor": 1,
-        "patch": 8
+        "patch": 9
       }
     }
   ]


### PR DESCRIPTION
## Problem
Base mainnet version metadata in info.json was outdated.
## Solution
- Bumped patch version for Base mainnet (0.1.8 → 0.1.9).
## Affected
- blockchains/info.json